### PR TITLE
Phase 3 — TinyDB History Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,6 @@ cython_debug/
 .vscode/
 
 chat_histories/
+data/history.json
 
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,9 @@ tests/
 - Centralize in `core/config.py` using `pydantic-settings`.
 - Load from env / `.env`. Never read secrets from code defaults.
 - All external clients (`ZulipClient`, `MySqlClient`, LLM) receive config via DI.
+- History storage defaults to TinyDB (`HISTORY_BACKEND=tinydb`); switch to filesystem with
+  `HISTORY_BACKEND=files`. Configure paths via `HISTORY_DB_PATH` / `HISTORY_FILES_DIR` and keep
+  `HISTORY_MAX_LENGTH` consistent with migrations.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -22,6 +22,12 @@ class Config(BaseSettings):
     GENAI_API_KEY:str = Field(..., env="GENAI_API_KEY")
     ZULIP_AUTH_TOKEN:str = Field(..., env="ZULIP_AUTH_TOKEN")
 
+    # History storage configuration
+    HISTORY_BACKEND: str = Field("tinydb", env="HISTORY_BACKEND")
+    HISTORY_DB_PATH: str = Field("./data/history.json", env="HISTORY_DB_PATH")
+    HISTORY_FILES_DIR: str = Field("./data/chat_histories", env="HISTORY_FILES_DIR")
+    HISTORY_MAX_LENGTH: int = Field(20, env="HISTORY_MAX_LENGTH")
+
     class Config:
         env_file = "./.env"
 

--- a/fred_zulip_bot/adapters/history_repo/__init__.py
+++ b/fred_zulip_bot/adapters/history_repo/__init__.py
@@ -1,1 +1,6 @@
 """History repository abstractions."""
+
+from fred_zulip_bot.adapters.history_repo.files_repo import FilesHistoryRepo
+from fred_zulip_bot.adapters.history_repo.tinydb_repo import TinyDbHistoryRepo
+
+__all__ = ["FilesHistoryRepo", "TinyDbHistoryRepo"]

--- a/fred_zulip_bot/adapters/history_repo/tinydb_repo.py
+++ b/fred_zulip_bot/adapters/history_repo/tinydb_repo.py
@@ -1,0 +1,60 @@
+"""TinyDB-backed history repository implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tinydb import Query, TinyDB
+
+from fred_zulip_bot.adapters.history_repo.base import HistoryRepository
+
+
+class TinyDbHistoryRepo(HistoryRepository):
+    """Persist chat histories in a TinyDB document store."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        max_length: int = 20,
+        table_name: str = "history",
+        logger: Any | None = None,
+    ) -> None:
+        self._db_path = db_path
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = TinyDB(self._db_path)
+        self._table = self._db.table(table_name)
+        self._max_length = max_length
+        self._logger = logger
+        self._query = Query()
+
+    def get(self, email: str) -> list[dict[str, Any]]:
+        record = self._table.get(self._query.email == email)
+        if record is None:
+            return []
+
+        if not isinstance(record, dict):
+            if self._logger is not None:
+                self._logger.warning("history record for %s is malformed; resetting", email)
+            return []
+
+        history = record.get("history", [])
+        if isinstance(history, list):
+            return [item for item in history if isinstance(item, dict)]
+
+        if self._logger is not None:
+            self._logger.warning("history record for %s is malformed; resetting", email)
+        return []
+
+    def save(self, email: str, history: list[dict[str, Any]]) -> None:
+        trimmed = history[-self._max_length :]
+        self._table.upsert(
+            {"email": email, "history": trimmed},
+            self._query.email == email,
+        )
+
+    def close(self) -> None:
+        """Close the underlying TinyDB instance."""
+
+        self._db.close()

--- a/fred_zulip_bot/apps/api/app.py
+++ b/fred_zulip_bot/apps/api/app.py
@@ -9,7 +9,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from config import config
+from fred_zulip_bot.adapters.history_repo.base import HistoryRepository
 from fred_zulip_bot.adapters.history_repo.files_repo import FilesHistoryRepo
+from fred_zulip_bot.adapters.history_repo.tinydb_repo import TinyDbHistoryRepo
 from fred_zulip_bot.adapters.mysql_client import MySqlClient
 from fred_zulip_bot.adapters.zulip_client import ZulipClient
 from fred_zulip_bot.apps.api.routes.chat import register_chat_routes
@@ -42,9 +44,20 @@ def create_app() -> FastAPI:
 
 
 def _build_services() -> dict[str, Any]:
-    base_history_dir = Path("./data/chat_histories")
-    history_repo = FilesHistoryRepo(base_history_dir, logger=logger)
+    history_backend = (config.HISTORY_BACKEND or "tinydb").lower()
+    max_length = config.HISTORY_MAX_LENGTH or 20
     sql_service = SqlService()
+
+    history_repo: HistoryRepository
+    if history_backend == "files":
+        base_history_dir = Path(config.HISTORY_FILES_DIR)
+        history_repo = FilesHistoryRepo(base_history_dir, max_length=max_length, logger=logger)
+    else:
+        history_repo = TinyDbHistoryRepo(
+            Path(config.HISTORY_DB_PATH),
+            max_length=max_length,
+            logger=logger,
+        )
 
     if config.TEST_MODE:
         zulip_email = config.ZULIP_BOT_EMAIL_TEST or config.ZULIP_BOT_EMAIL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ addopts = "-q --cov=fred_zulip_bot --cov-report=term-missing"
 testpaths = ["tests"]
 
 [[tool.mypy.overrides]]
-module = ["requests", "google.generativeai", "mysql.connector"]
+module = ["requests", "google.generativeai", "mysql.connector", "tinydb"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tools/migrate_history_to_tinydb.py
+++ b/tools/migrate_history_to_tinydb.py
@@ -1,0 +1,96 @@
+"""Migrate existing JSON chat histories into TinyDB."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from tinydb import Query, TinyDB
+
+DEFAULT_SOURCE = Path("./data/chat_histories")
+DEFAULT_DEST = Path("./data/history.json")
+DEFAULT_TABLE = "history"
+DEFAULT_MAX_LENGTH = 20
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_SOURCE,
+        help="Directory containing legacy JSON history files",
+    )
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=DEFAULT_DEST,
+        help="Destination TinyDB file path",
+    )
+    parser.add_argument(
+        "--table",
+        default=DEFAULT_TABLE,
+        help="TinyDB table name to use",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=DEFAULT_MAX_LENGTH,
+        help="Maximum history length to retain per user",
+    )
+    args = parser.parse_args()
+
+    source_dir = args.source
+    db_path = args.dest
+    table_name = args.table
+    max_length = args.max_length
+
+    if not source_dir.exists():
+        raise SystemExit(f"source directory {source_dir} does not exist")
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    db = TinyDB(db_path)
+    table = db.table(table_name)
+    query = Query()
+
+    migrated = 0
+    skipped = 0
+
+    for file_path in sorted(source_dir.glob("*.json")):
+        email = _unsanitize_email(file_path.stem)
+        history = _load_history(file_path)
+        if not history:
+            skipped += 1
+            continue
+
+        trimmed = history[-max_length:]
+        table.upsert({"email": email, "history": trimmed}, query.email == email)
+        migrated += 1
+
+    db.close()
+
+    print(f"Migrated {migrated} histories into {db_path} (table {table_name}).")
+    if skipped:
+        print(f"Skipped {skipped} empty or unreadable files.")
+
+
+def _load_history(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return []
+
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _unsanitize_email(value: str) -> str:
+    return value.replace("_dot_", ".").replace("_at_", "@")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a TinyDB-backed history repository and make it the default backend via config
- keep the filesystem repo available behind HISTORY_BACKEND=files and surface new history settings
- ship a migration utility to import existing JSON histories into TinyDB storage

## Testing
- ruff check fred_zulip_bot tools tests
- ruff format --check fred_zulip_bot tools tests
- mypy fred_zulip_bot
- pytest
