### PR TITLE
Phase 4 — Minimal LangGraph Wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ This document is the playbook for refactoring and extending **unfoldingWord/fred
 - **Local Checks Before Every Commit (non-negotiable):** run `ruff check fred_zulip_bot tests`,
   `ruff format --check fred_zulip_bot tests`, `mypy fred_zulip_bot`, and `pytest`. Pre-commit hooks
   will fail if you forget, but you must run them manually first.
+- **Match CI Dependencies:** Always install both `requirements.txt` and `requirements-dev.txt`
+  before running the checks so mypy/pytest exercise the same dependency graph that CI uses.
 - **Messages:** **Never** commit with an empty description—subject **and** body are required.
 
 ---

--- a/config.py
+++ b/config.py
@@ -31,6 +31,7 @@ class Config(BaseSettings):
     HISTORY_DB_PATH: str = "./data/history.json"
     HISTORY_FILES_DIR: str = "./data/chat_histories"
     HISTORY_MAX_LENGTH: int = 20
+    ENABLE_LANGGRAPH: bool = False
 
 
 config = Config()  # type: ignore[call-arg]

--- a/fred_zulip_bot/adapters/mysql_client.py
+++ b/fred_zulip_bot/adapters/mysql_client.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from typing import Any
 
-import mysql.connector
+try:
+    MYSQL_CONNECTOR: Any = import_module("mysql.connector")
+except ModuleNotFoundError as exc:  # pragma: no cover - hard dependency
+    raise RuntimeError("mysql-connector-python is required to use MySqlClient") from exc
 
 
 class MySqlClient:
@@ -29,7 +33,7 @@ class MySqlClient:
 
     def select(self, sql: str) -> str:
         try:
-            conn = mysql.connector.connect(
+            conn = MYSQL_CONNECTOR.connect(
                 host=self._host,
                 port=self._port,
                 database=self._database,

--- a/fred_zulip_bot/apps/api/app.py
+++ b/fred_zulip_bot/apps/api/app.py
@@ -90,6 +90,7 @@ def _build_services() -> dict[str, Any]:
         auth_token=auth_token,
         logger=logger,
         api_key=config.GENAI_API_KEY,
+        enable_langgraph=config.ENABLE_LANGGRAPH,
     )
 
     return {

--- a/fred_zulip_bot/orchestration/__init__.py
+++ b/fred_zulip_bot/orchestration/__init__.py
@@ -1,0 +1,1 @@
+"""LangGraph orchestration utilities."""

--- a/fred_zulip_bot/orchestration/graph.py
+++ b/fred_zulip_bot/orchestration/graph.py
@@ -1,0 +1,128 @@
+"""LangGraph orchestration helpers for chat processing."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Protocol, TypedDict, cast
+
+from fred_zulip_bot.core.models import ChatRequest, ZulipMessage
+
+try:
+    LANGGRAPH_GRAPH: ModuleType = import_module("langgraph.graph")
+except ModuleNotFoundError as exc:  # pragma: no cover - hard dependency
+    raise RuntimeError("langgraph is required to build the chat orchestration graph") from exc
+
+END: Any = LANGGRAPH_GRAPH.END
+StateGraph: Any = LANGGRAPH_GRAPH.StateGraph
+
+
+class ChatGraphService(Protocol):
+    """Interface required by the LangGraph orchestration builder."""
+
+    def classify_intent(self, message: ZulipMessage) -> str: ...
+
+    def handle_chatbot(
+        self,
+        message: ZulipMessage,
+        history: list[dict[str, Any]],
+    ) -> str: ...
+
+    def handle_other(
+        self,
+        message: ZulipMessage,
+        history: list[dict[str, Any]],
+    ) -> str: ...
+
+    def handle_database(
+        self,
+        message: ZulipMessage,
+        history: list[dict[str, Any]],
+    ) -> tuple[str, str, str]: ...
+
+
+class GraphState(TypedDict, total=False):
+    """State container passed through the LangGraph nodes."""
+
+    request: ChatRequest
+    history: list[dict[str, Any]]
+    intent: str | None
+    sql: str | None
+    result: str | None
+    response: str | None
+
+
+class GraphRunner(Protocol):
+    """Subset of the LangGraph runner interface used by the chat service."""
+
+    def invoke(self, state: GraphState) -> GraphState: ...
+
+
+def build_chat_graph(*, chat_service: ChatGraphService, logger: Any) -> GraphRunner:
+    """Return a compiled LangGraph that mirrors the legacy chat flow."""
+
+    graph = StateGraph(GraphState)
+
+    def classify_intent_node(state: GraphState) -> dict[str, Any]:
+        request = state["request"]
+        intent = chat_service.classify_intent(request.message)
+        logger.info("LangGraph node=classify_intent intent=%s", intent)
+        return {"intent": intent}
+
+    def route_intent(state: GraphState) -> str:
+        intent = state.get("intent")
+        if isinstance(intent, str):
+            cleaned = intent.strip().lower()
+            if cleaned in {"chatbot", "other", "database"}:
+                return cleaned
+        return "other"
+
+    def chatbot_node(state: GraphState) -> dict[str, Any]:
+        request = state["request"]
+        history = state["history"]
+        response = chat_service.handle_chatbot(request.message, history)
+        logger.info("LangGraph node=chatbot response_chars=%s", len(response or ""))
+        return {"response": response}
+
+    def other_node(state: GraphState) -> dict[str, Any]:
+        request = state["request"]
+        history = state["history"]
+        response = chat_service.handle_other(request.message, history)
+        logger.info("LangGraph node=other response_chars=%s", len(response or ""))
+        return {"response": response}
+
+    def database_node(state: GraphState) -> dict[str, Any]:
+        request = state["request"]
+        history = state["history"]
+        response, sql_text, result_text = chat_service.handle_database(
+            request.message,
+            history,
+        )
+        logger.info("LangGraph node=database has_sql=%s", bool(sql_text))
+        return {
+            "response": response,
+            "sql": sql_text,
+            "result": result_text,
+        }
+
+    graph.add_node("classify_intent", classify_intent_node)
+    graph.add_node("chatbot", chatbot_node)
+    graph.add_node("other", other_node)
+    graph.add_node("database", database_node)
+
+    graph.set_entry_point("classify_intent")
+    graph.add_conditional_edges(
+        "classify_intent",
+        route_intent,
+        {
+            "chatbot": "chatbot",
+            "other": "other",
+            "database": "database",
+        },
+    )
+    graph.add_edge("chatbot", END)
+    graph.add_edge("other", END)
+    graph.add_edge("database", END)
+
+    compiled = graph.compile()
+    return cast(GraphRunner, compiled)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic-settings==2.5.2
 tinydb==4.8.0
 requests==2.32.4
 google-generativeai==0.8.5
+langgraph==0.6.8
 
 # Database connectors
 mysql-connector-python==9.3.0


### PR DESCRIPTION
## Summary
- add the ENABLE_LANGGRAPH flag and LangGraph dependency without changing defaults
- build the chat orchestration graph so existing handlers run when the flag is enabled
- refactor chat service helpers to share behavior between the legacy path and LangGraph

## Testing
- ruff format --check fred_zulip_bot tests
- ruff check fred_zulip_bot tests
- mypy fred_zulip_bot
- python3 -m pytest -q