### PR TITLE
Phase 5 — Intent Enum

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_intent_service.py
+++ b/tests/test_intent_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fred_zulip_bot.services.intent_service import IntentType, classify_intent
+
+
+@dataclass
+class DummyReply:
+    text: str
+
+
+def make_asker(result: str):
+    def ask(prompt: str, use_history: bool) -> DummyReply:
+        return DummyReply(result)
+
+    return ask
+
+
+def test_classify_intent_database_label() -> None:
+    intent = classify_intent(make_asker("database"))
+    assert intent is IntentType.DATABASE  # noqa: S101
+
+
+def test_classify_intent_trims_and_lowercases() -> None:
+    intent = classify_intent(make_asker("  ChatBot\n"))
+    assert intent is IntentType.CHATBOT  # noqa: S101
+
+
+def test_classify_intent_defaults_to_other() -> None:
+    intent = classify_intent(make_asker("something else"))
+    assert intent is IntentType.OTHER  # noqa: S101


### PR DESCRIPTION
## Summary
- add an explicit IntentType enum and typed classify_intent helper
- switch ChatService and the LangGraph state machine to dispatch on the enum
- add minimal tests covering normalization and fallback behaviour

## Testing
- ruff format --check fred_zulip_bot tests
- ruff check fred_zulip_bot tests
- mypy fred_zulip_bot
- python3 -m pytest -q