### PR TITLE
Phase 6 — CI Strict Gates

### DIFF
--- a/docs/refactor_plan.md
+++ b/docs/refactor_plan.md
@@ -373,7 +373,7 @@ fred_zulip_bot/
 
 **Gates**
 - pre-commit on changed files: `ruff`, `mypy`, `pytest -q`.
-- CI coverage threshold: start at 70%, ratchet up later.
+- CI coverage threshold: start at 70%; enforce with `--cov-fail-under=70` in `pytest` addopts.
 
 ---
 

--- a/fred_zulip_bot/orchestration/graph.py
+++ b/fred_zulip_bot/orchestration/graph.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import Any, Protocol, TypedDict, cast
+from typing import Any, Optional, Protocol, TypedDict, cast
 
 from fred_zulip_bot.core.models import ChatRequest, ZulipMessage
 from fred_zulip_bot.services.intent_service import IntentType
@@ -47,10 +47,10 @@ class GraphState(TypedDict, total=False):
 
     request: ChatRequest
     history: list[dict[str, Any]]
-    intent: IntentType | None
-    sql: str | None
-    result: str | None
-    response: str | None
+    intent: Optional[IntentType]  # noqa: UP007
+    sql: Optional[str]  # noqa: UP007
+    result: Optional[str]  # noqa: UP007
+    response: Optional[str]  # noqa: UP007
 
 
 class GraphRunner(Protocol):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ disallow_untyped_defs = true
 mypy_path = "stubs"
 
 [tool.pytest.ini_options]
-addopts = "-q --cov=fred_zulip_bot --cov-report=term-missing"
+addopts = "-q --cov=fred_zulip_bot --cov-report=term-missing --cov-fail-under=70"
 testpaths = ["tests"]
 
 [[tool.mypy.overrides]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,33 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import ModuleType
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+class _StubGenerativeModel:
+    def __init__(self, **_: object) -> None:  # pragma: no cover - trivial stub
+        pass
+
+
+def _configure_stub(**_: object) -> None:  # pragma: no cover - trivial stub
+    pass
+
+
+stub_module = ModuleType("google.generativeai")
+stub_module.configure = _configure_stub  # type: ignore[attr-defined]
+stub_module.GenerativeModel = _StubGenerativeModel  # type: ignore[attr-defined]
+
+sys.modules.setdefault("google.generativeai", stub_module)
+
+
+mysql_module = ModuleType("mysql")
+mysql_connector = ModuleType("mysql.connector")
+mysql_connector.connect = lambda **_: None  # type: ignore[attr-defined]
+mysql_module.connector = mysql_connector  # type: ignore[attr-defined]
+
+sys.modules.setdefault("mysql", mysql_module)
+sys.modules.setdefault("mysql.connector", mysql_connector)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+
+class DummyHistoryRepo:
+    def __init__(self, path, *, max_length, logger):  # type: ignore[override]
+        self.path = path
+        self.max_length = max_length
+        self.logger = logger
+
+
+class DummyZulipClient:
+    def __init__(self, **_: Any) -> None:
+        pass
+
+
+class DummyMySqlClient:
+    def __init__(self, **_: Any) -> None:
+        pass
+
+
+class DummyChatService:
+    def __init__(self, **_: Any) -> None:
+        pass
+
+    def handle_chat_request(self, request, background_tasks):  # pragma: no cover
+        raise NotImplementedError
+
+
+class DummyConfig:
+    TEST_MODE = True
+    ZULIP_BOT_EMAIL_TEST = "bot@example.com"
+    ZULIP_BOT_TOKEN_TEST = "token"  # noqa: S105
+    ZULIP_AUTH_TOKEN_TEST = "auth"  # noqa: S105
+    ZULIP_SITE = "https://example.com"
+    DB_HOST = "localhost"
+    DB_NAME = "db"
+    DB_USER = "user"
+    DB_PASSWORD = "pw"  # noqa: S105
+    GENAI_API_KEY = "key"
+    HISTORY_DB_PATH = "history.json"
+    HISTORY_MAX_LENGTH = 5
+    ENABLE_LANGGRAPH = False
+
+
+@pytest.fixture
+def app_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ZULIP_BOT_TOKEN", "token")
+    monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+    monkeypatch.setenv("ZULIP_SITE", "https://example.com")
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_NAME", "db")
+    monkeypatch.setenv("DB_USER", "user")
+    monkeypatch.setenv("DB_PASSWORD", "pw")
+    monkeypatch.setenv("GENAI_API_KEY", "key")
+    monkeypatch.setenv("ZULIP_AUTH_TOKEN", "auth")
+
+    module = importlib.import_module("fred_zulip_bot.apps.api.app")
+    module = importlib.reload(module)
+    return module
+
+
+def test_create_app_sets_up_services(monkeypatch: pytest.MonkeyPatch, app_module) -> None:
+    monkeypatch.setattr(app_module, "TinyDbHistoryRepo", DummyHistoryRepo)
+    monkeypatch.setattr(app_module, "ZulipClient", DummyZulipClient)
+    monkeypatch.setattr(app_module, "MySqlClient", DummyMySqlClient)
+    monkeypatch.setattr(app_module, "ChatService", DummyChatService)
+    monkeypatch.setattr(app_module, "config", DummyConfig)
+
+    app = app_module.create_app()
+
+    assert "chat_service" in app.state.services  # noqa: S101
+    assert app.state.services["history_repo"].max_length == DummyConfig.HISTORY_MAX_LENGTH  # noqa: S101

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from fred_zulip_bot.core.models import ChatRequest, ZulipMessage
+from fred_zulip_bot.services import intent_service
+from fred_zulip_bot.services.chat_service import ChatService
+from fred_zulip_bot.services.sql_service import SqlService
+
+
+@dataclass
+class FakeHistoryRepo:
+    store: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+    def get(self, email: str) -> list[dict[str, Any]]:
+        return list(self.store.get(email, []))
+
+    def save(self, email: str, history: list[dict[str, Any]]) -> None:
+        self.store[email] = list(history)
+
+
+@dataclass
+class FakeZulipClient:
+    sent: list[dict[str, Any]] = field(default_factory=list)
+
+    def send(self, **kwargs: Any) -> None:
+        self.sent.append(kwargs)
+
+
+@dataclass
+class FakeMySqlClient:
+    result: str
+
+    def __init__(self, result: str) -> None:
+        self.result = result
+
+    def select(self, sql: str) -> str:
+        self.last_query = sql
+        return self.result
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.infos: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.errors: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.infos.append((message, args, kwargs))
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.errors.append((message, args, kwargs))
+
+
+class DummyReply:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+@pytest.fixture
+def sql_service(tmp_path):
+    ddl = tmp_path / "ddl.txt"
+    ddl.write_text("ddl")
+    rules = tmp_path / "rules.txt"
+    rules.write_text("rules")
+    return SqlService(ddl_path=ddl, rules_path=rules)
+
+
+def build_service(
+    monkeypatch: pytest.MonkeyPatch,
+    sql_service: SqlService,
+    *,
+    intent_label: str,
+    chatbot_reply: str | None = None,
+    other_reply: str | None = None,
+    sql_text: str | None = None,
+    db_result: str = "rows",
+    summary_text: str | None = None,
+    use_langgraph: bool = False,
+) -> tuple[ChatService, FakeZulipClient, FakeHistoryRepo, FakeMySqlClient, DummyLogger]:
+    monkeypatch.setattr(ChatService, "_configure_genai", lambda self, api_key: None)
+
+    mapping: dict[str, str] = {intent_service.INTENT_PROMPT: intent_label}
+
+    if chatbot_reply is not None:
+        mapping[intent_service.CHATBOT_PROMPT] = chatbot_reply
+    if other_reply is not None:
+        mapping[intent_service.OTHER_PROMPT] = other_reply
+    if sql_text is not None:
+        mapping[sql_service.sql_prompt] = sql_text
+    if summary_text is not None:
+        mapping[sql_service.answer_prompt] = summary_text
+
+    def fake_ask_model(
+        self, message, prompt, use_history, *, model_override=None, allow_fallback=True
+    ):  # type: ignore[override]
+        try:
+            text = mapping[prompt]
+        except KeyError as exc:  # pragma: no cover - guard
+            raise AssertionError(f"Unexpected prompt: {prompt!r}") from exc
+        return DummyReply(text)
+
+    monkeypatch.setattr(ChatService, "_ask_model", fake_ask_model)
+
+    fake_history = FakeHistoryRepo()
+    fake_zulip = FakeZulipClient()
+    fake_mysql = FakeMySqlClient(db_result)
+    logger = DummyLogger()
+
+    service = ChatService(
+        zulip_client=fake_zulip,
+        history_repo=fake_history,
+        mysql_client=fake_mysql,
+        sql_service=sql_service,
+        auth_token="secret",  # noqa: S106
+        logger=logger,
+        api_key="api-key",
+        enable_langgraph=use_langgraph,
+    )
+
+    return service, fake_zulip, fake_history, fake_mysql, logger
+
+
+def make_request(content: str) -> ChatRequest:
+    message = ZulipMessage(
+        content=content,
+        display_recipient="stream",
+        sender_email="user@example.com",
+        subject="topic",
+        type="stream",
+    )
+    return ChatRequest(message=message, token="secret")  # noqa: S106
+
+
+def test_process_user_message_chatbot(monkeypatch, sql_service):
+    service, zulip, history, _, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="chatbot",
+        chatbot_reply="Hello there",
+    )
+
+    service.process_user_message(make_request("hi"))
+
+    assert zulip.sent[0]["content"] == "Hello there"  # noqa: S101
+    saved = history.get("user@example.com")
+    assert saved[-1]["parts"] == ["Hello there"]  # noqa: S101
+
+
+def test_process_user_message_database_flow(monkeypatch, sql_service):
+    service, zulip, history, mysql, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="database",
+        sql_text="SELECT 1",
+        db_result="(1,)",
+        summary_text="There is one result.",
+    )
+
+    service.process_user_message(make_request("how many?"))
+
+    assert mysql.last_query == "SELECT 1"  # noqa: S101
+    assert zulip.sent[0]["content"] == "There is one result."  # noqa: S101
+    saved = history.get("user@example.com")
+    assert saved[-1]["parts"] == ["There is one result."]  # noqa: S101
+
+
+def test_process_user_message_other(monkeypatch, sql_service):
+    service, zulip, history, _, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="other",
+        other_reply="Cannot help",
+    )
+
+    service.process_user_message(make_request("other question"))
+
+    assert zulip.sent[0]["content"] == "Cannot help"  # noqa: S101
+    saved = history.get("user@example.com")
+    assert saved[-1]["parts"] == ["Cannot help"]  # noqa: S101
+
+
+def test_handle_chat_request_rejects_invalid_token(monkeypatch, sql_service):
+    service, _, _, _, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="chatbot",
+        chatbot_reply="Hi",
+    )
+
+    request = make_request("hi")
+    request.token = "bad"  # noqa: S105
+
+    with pytest.raises(HTTPException) as exc:
+        service.handle_chat_request(request, BackgroundTasks())
+
+    assert exc.value.status_code == 401  # noqa: S101
+
+
+def test_process_user_message_database_salvage(monkeypatch, sql_service):
+    service, zulip, history, mysql, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="database",
+        sql_text="SELECT name",
+        db_result="salvage",
+        summary_text="Use fallback",
+    )
+
+    service.process_user_message(make_request("fallback?"))
+
+    assert mysql.last_query == "SELECT name"  # noqa: S101
+    assert zulip.sent[0]["content"] == "Use fallback"  # noqa: S101
+    saved = history.get("user@example.com")
+    assert saved[-1]["parts"] == ["Use fallback"]  # noqa: S101
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="LangGraph requires Python >= 3.10")
+def test_process_user_message_with_langgraph(monkeypatch, sql_service):
+    service, zulip, history, _, _ = build_service(
+        monkeypatch,
+        sql_service,
+        intent_label="chatbot",
+        chatbot_reply="LangGraph reply",
+        use_langgraph=True,
+    )
+
+    service.process_user_message(make_request("hi"))
+
+    assert zulip.sent[0]["content"] == "LangGraph reply"  # noqa: S101
+    assert history.get("user@example.com")[-1]["parts"] == ["LangGraph reply"]  # noqa: S101

--- a/tests/test_history_repo.py
+++ b/tests/test_history_repo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fred_zulip_bot.adapters.history_repo.tinydb_repo import TinyDbHistoryRepo
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def warning(self, message: str, *args, **kwargs) -> None:
+        self.messages.append(message % args if args else message)
+
+
+def test_tinydb_history_repo_roundtrip(tmp_path: Path) -> None:
+    repo = TinyDbHistoryRepo(tmp_path / "history.json", max_length=2, logger=DummyLogger())
+
+    assert repo.get("user@example.com") == []  # noqa: S101
+
+    sample = [
+        {"role": "user", "parts": ["hi"]},
+        {"role": "model", "parts": ["hello"]},
+        {"role": "user", "parts": ["follow-up"]},
+    ]
+
+    repo.save("user@example.com", sample)
+    saved = repo.get("user@example.com")
+
+    assert len(saved) == 2  # noqa: S101
+    assert saved[0]["parts"] == ["hello"]  # noqa: S101
+    assert saved[1]["parts"] == ["follow-up"]  # noqa: S101
+
+
+def test_tinydb_history_repo_handles_malformed(tmp_path: Path) -> None:
+    logger = DummyLogger()
+    repo = TinyDbHistoryRepo(tmp_path / "history.json", max_length=2, logger=logger)
+
+    repo._table.insert({"email": "user@example.com", "history": "oops"})
+
+    assert repo.get("user@example.com") == []  # noqa: S101
+    assert logger.messages  # noqa: S101

--- a/tests/test_mysql_client.py
+++ b/tests/test_mysql_client.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fred_zulip_bot.adapters.mysql_client import MySqlClient
+
+
+class DummyCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+        self.executed_sql: str | None = None
+
+    def execute(self, sql: str) -> None:
+        self.executed_sql = sql
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+    def close(self) -> None:  # pragma: no cover - no behavior
+        pass
+
+
+class DummyConnection:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+        self.closed = False
+        self.cursor_obj = DummyCursor(rows)
+
+    def cursor(self) -> DummyCursor:
+        return self.cursor_obj
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.logged = False
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.logged = True
+
+
+def test_mysql_client_select_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [(1,), (2,)]
+    connection = DummyConnection(rows)
+    monkeypatch.setattr(
+        "fred_zulip_bot.adapters.mysql_client.MYSQL_CONNECTOR",
+        type("Connector", (), {"connect": staticmethod(lambda **kwargs: connection)}),
+    )
+
+    client = MySqlClient(
+        host="host",
+        database="db",
+        user="user",
+        password="test-pw",  # noqa: S106
+        logger=DummyLogger(),
+    )
+
+    result = client.select("SELECT 1")
+
+    assert result.strip() == "(1,), (2,),"  # noqa: S101
+    assert connection.cursor_obj.executed_sql == "SELECT 1"  # noqa: S101
+    assert connection.closed is True  # noqa: S101
+
+
+def test_mysql_client_select_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "fred_zulip_bot.adapters.mysql_client.MYSQL_CONNECTOR",
+        type(
+            "Connector",
+            (),
+            {"connect": staticmethod(lambda **kwargs: (_ for _ in ()).throw(RuntimeError("fail")))},
+        ),
+    )
+
+    logger = DummyLogger()
+    client = MySqlClient(
+        host="host",
+        database="db",
+        user="user",
+        password="test-pw",  # noqa: S106
+        logger=logger,
+    )
+
+    result = client.select("SELECT 1")
+
+    assert result == "salvage"  # noqa: S101
+    assert logger.logged is True  # noqa: S101

--- a/tests/test_orchestration_graph.py
+++ b/tests/test_orchestration_graph.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+if sys.version_info < (3, 10):  # pragma: no cover - compatibility guard  # noqa: UP036
+    pytest.skip("LangGraph requires Python >= 3.10", allow_module_level=True)
+
+from fred_zulip_bot.core.models import ChatRequest, ZulipMessage
+from fred_zulip_bot.orchestration.graph import GraphState, build_chat_graph
+from fred_zulip_bot.services.intent_service import IntentType
+
+
+@dataclass
+class StubService:
+    intents: list[IntentType]
+    responses: dict[IntentType, tuple[str, str, str]]
+    calls: list[str] = field(default_factory=list)
+
+    def classify_intent(self, message: ZulipMessage) -> IntentType:
+        self.calls.append(f"classify:{message.content}")
+        return self.intents.pop(0)
+
+    def handle_chatbot(self, message: ZulipMessage, history: list[dict[str, Any]]) -> str:
+        self.calls.append("chatbot")
+        return self.responses[IntentType.CHATBOT][0]
+
+    def handle_other(self, message: ZulipMessage, history: list[dict[str, Any]]) -> str:
+        self.calls.append("other")
+        return self.responses[IntentType.OTHER][0]
+
+    def handle_database(
+        self, message: ZulipMessage, history: list[dict[str, Any]]
+    ) -> tuple[str, str, str]:
+        self.calls.append("database")
+        return self.responses[IntentType.DATABASE]
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.events.append(message % args if args else message)
+
+
+def make_request(content: str) -> ChatRequest:
+    return ChatRequest(
+        message=ZulipMessage(
+            content=content,
+            display_recipient="stream",
+            sender_email="user@example.com",
+            subject="topic",
+            type="stream",
+        ),
+        token="token",  # noqa: S106
+    )
+
+
+def test_graph_routes_chatbot() -> None:
+    service = StubService(
+        intents=[IntentType.CHATBOT],
+        responses={
+            IntentType.CHATBOT: ("hi", "", ""),
+            IntentType.OTHER: ("", "", ""),
+            IntentType.DATABASE: ("", "", ""),
+        },
+    )
+    logger = DummyLogger()
+    runner = build_chat_graph(chat_service=service, logger=logger)
+
+    result = runner.invoke(GraphState(request=make_request("hello"), history=[], intent=None))
+
+    assert result["response"] == "hi"  # noqa: S101
+    assert "chatbot" in service.calls  # noqa: S101
+
+
+def test_graph_routes_database() -> None:
+    service = StubService(
+        intents=[IntentType.DATABASE],
+        responses={
+            IntentType.CHATBOT: ("", "", ""),
+            IntentType.OTHER: ("", "", ""),
+            IntentType.DATABASE: ("answer", "SQL", "RESULT"),
+        },
+    )
+    logger = DummyLogger()
+    runner = build_chat_graph(chat_service=service, logger=logger)
+
+    result = runner.invoke(GraphState(request=make_request("data"), history=[], intent=None))
+
+    assert result["response"] == "answer"  # noqa: S101
+    assert result["sql"] == "SQL"  # noqa: S101
+    assert result["result"] == "RESULT"  # noqa: S101
+
+
+def test_graph_default_to_other() -> None:
+    service = StubService(
+        intents=[IntentType.OTHER],
+        responses={
+            IntentType.CHATBOT: ("", "", ""),
+            IntentType.OTHER: ("fallback", "", ""),
+            IntentType.DATABASE: ("", "", ""),
+        },
+    )
+    logger = DummyLogger()
+    runner = build_chat_graph(chat_service=service, logger=logger)
+
+    result = runner.invoke(GraphState(request=make_request("unknown"), history=[], intent=None))
+
+    assert result["response"] == "fallback"  # noqa: S101

--- a/tests/test_routes_chat.py
+++ b/tests/test_routes_chat.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.testclient import TestClient
+
+from fred_zulip_bot.apps.api.routes.chat import register_chat_routes
+from fred_zulip_bot.core.models import ChatRequest, ChatResponse
+
+
+class StubChatService:
+    def __init__(self) -> None:
+        self.calls: list[ChatRequest] = []
+
+    def handle_chat_request(
+        self, request: ChatRequest, background_tasks: BackgroundTasks
+    ) -> ChatResponse:
+        self.calls.append(request)
+        return ChatResponse()
+
+
+def test_chat_route_invokes_service() -> None:
+    app = FastAPI()
+    stub = StubChatService()
+    app.state.services = {"chat_service": stub}
+    register_chat_routes(app)
+
+    client = TestClient(app)
+
+    payload = {
+        "message": {
+            "content": "hello",
+            "display_recipient": "stream",
+            "sender_email": "user@example.com",
+            "subject": "topic",
+            "type": "stream",
+        },
+        "token": "secret",
+    }
+
+    response = client.post("/chat", json=payload)
+
+    assert response.status_code == 200  # noqa: S101
+    assert stub.calls[0].message.content == "hello"  # noqa: S101

--- a/tests/test_routes_health.py
+++ b/tests/test_routes_health.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fred_zulip_bot.apps.api.routes.health import register_health_routes
+
+
+def test_health_routes_return_ok() -> None:
+    app = FastAPI()
+    register_health_routes(app)
+    client = TestClient(app)
+
+    health_response = client.get("/healthz")
+    ready_response = client.get("/ready")
+
+    assert health_response.status_code == 200  # noqa: S101
+    assert ready_response.status_code == 200  # noqa: S101

--- a/tests/test_sql_service.py
+++ b/tests/test_sql_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fred_zulip_bot.services.sql_service import SqlService
+
+
+@pytest.fixture
+def sql_service(tmp_path: Path) -> SqlService:
+    ddl = tmp_path / "ddl.txt"
+    ddl.write_text("table info")
+    rules = tmp_path / "rules.txt"
+    rules.write_text("rules info")
+    return SqlService(ddl_path=ddl, rules_path=rules)
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "SELECT * FROM projects",
+        "select name FROM users WHERE id = 1",
+    ],
+)
+def test_is_safe_sql_allows_selects(sql_service: SqlService, statement: str) -> None:
+    assert sql_service.is_safe_sql(statement) is True  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "UPDATE projects SET name='x'",
+        "DELETE FROM users",
+        "SELECT * FROM data; DROP TABLE data",
+        "SELECT * FROM x WHERE name LIKE 'test';",
+        "SELECT * FROM x -- comment",
+        "SELECT * FROM x /* no */",
+        "SELECT * INTO OUTFILE 'x' FROM y",
+    ],
+)
+def test_is_safe_sql_rejects_dangerous_statements(sql_service: SqlService, statement: str) -> None:
+    assert sql_service.is_safe_sql(statement) is False  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "  ",
+        "DESCRIBE table",
+        "INSERT INTO table VALUES (1)",
+    ],
+)
+def test_is_safe_sql_rejects_non_select(sql_service: SqlService, statement: str) -> None:
+    assert sql_service.is_safe_sql(statement) is False  # noqa: S101

--- a/tests/test_zulip_client.py
+++ b/tests/test_zulip_client.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fred_zulip_bot.adapters.zulip_client import ZulipClient
+
+
+def test_zulip_client_send_stream(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_post(url, data, auth, timeout):  # type: ignore[override]
+        captured["url"] = url
+        captured["data"] = data
+        captured["auth"] = auth
+        captured["timeout"] = timeout
+
+    monkeypatch.setattr("fred_zulip_bot.adapters.zulip_client.requests.post", fake_post)
+
+    client = ZulipClient(realm_url="https://example.com/", email="bot@example.com", api_key="key")
+
+    client.send(
+        to=["recipient@example.com"],
+        msg_type="stream",
+        subject="topic",
+        content="hello",
+        channel_name="general",
+    )
+
+    expected = {
+        "url": "https://example.com/api/v1/messages",
+        "data": {
+            "type": "stream",
+            "to": "general",
+            "content": "hello",
+            "subject": "topic",
+        },
+        "auth": ("bot@example.com", "key"),
+        "timeout": 10,
+    }
+    assert captured == expected  # noqa: S101
+
+
+def test_zulip_client_send_private(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_post(url, data, auth, timeout):  # type: ignore[override]
+        captured.update({"data": data, "auth": auth})
+
+    monkeypatch.setattr("fred_zulip_bot.adapters.zulip_client.requests.post", fake_post)
+
+    client = ZulipClient(realm_url="https://example.com", email="bot@example.com", api_key="key")
+    client.send(
+        to=["user@example.com"],
+        msg_type="private",
+        subject="ignored",
+        content="hi",
+        channel_name="ignored",
+    )
+
+    expected = {
+        "data": {"type": "private", "to": ["user@example.com"], "content": "hi"},
+        "auth": ("bot@example.com", "key"),
+    }
+    assert captured == expected  # noqa: S101


### PR DESCRIPTION
## Summary
- add unit and route tests covering chat service, adapters, and orchestration to meet coverage goals
- enforce pytest coverage with --cov-fail-under=70 and stub external clients for isolated tests
- adjust LangGraph typing for Python 3.9 compatibility and update the refactor plan with the new gate

## Testing
- ruff check fred_zulip_bot tests
- mypy fred_zulip_bot
- python3 -m pytest