### PR TITLE
feat: add user progress updates

### DIFF
--- a/fred_zulip_bot/services/chat_service.py
+++ b/fred_zulip_bot/services/chat_service.py
@@ -27,7 +27,7 @@ _SQL_PREPROCESS_LOG_SNIPPET_LENGTH = 240
 
 _PROGRESS_CLASSIFY = "Figuring out the best way to help."
 _PROGRESS_QUERY = "Checking the database for the details you asked about."
-_PROGRESS_SUMMARY = "I have the data - summarizing it for you now."
+_PROGRESS_SUMMARY = "I have the data - summarizing it for you now..."
 _PROGRESS_CHATBOT = "Drafting a reply about how I work."
 _PROGRESS_UNSUPPORTED = "Working on a helpful explanation since I can't do that directly."
 _PROGRESS_UNSAFE = "That request looked unsafe, so I'm sending a fallback instead."

--- a/fred_zulip_bot/services/chat_service.py
+++ b/fred_zulip_bot/services/chat_service.py
@@ -25,10 +25,10 @@ DEFAULT_FALLBACK_MESSAGE = (
 _SQL_PREPROCESS_HISTORY_LIMIT = 6
 _SQL_PREPROCESS_LOG_SNIPPET_LENGTH = 240
 
-_PROGRESS_CLASSIFY = "Figuring out the best way to help..."
-_PROGRESS_QUERY = "Checking the database for the details you asked about..."
-_PROGRESS_SUMMARY = "I have the data - summarizing it for you now..."
-_PROGRESS_CHATBOT = "Drafting a reply about how I work..."
+_PROGRESS_CLASSIFY = "Figuring out the best way to help."
+_PROGRESS_QUERY = "Checking the database for the details you asked about."
+_PROGRESS_SUMMARY = "I have the data - summarizing it for you now."
+_PROGRESS_CHATBOT = "Drafting a reply about how I work."
 _PROGRESS_UNSUPPORTED = "Working on a helpful explanation since I can't do that directly."
 _PROGRESS_UNSAFE = "That request looked unsafe, so I'm sending a fallback instead."
 

--- a/fred_zulip_bot/services/chat_service.py
+++ b/fred_zulip_bot/services/chat_service.py
@@ -25,10 +25,9 @@ DEFAULT_FALLBACK_MESSAGE = (
 _SQL_PREPROCESS_HISTORY_LIMIT = 6
 _SQL_PREPROCESS_LOG_SNIPPET_LENGTH = 240
 
-_PROGRESS_INITIAL = "Thanks for your patience - I'm reviewing your request now."
 _PROGRESS_CLASSIFY = "Figuring out the best way to help..."
 _PROGRESS_QUERY = "Checking the database for the details you asked about..."
-_PROGRESS_SUMMARY = "I have the data - summarizing it for you now."
+_PROGRESS_SUMMARY = "I have the data - summarizing it for you now..."
 _PROGRESS_CHATBOT = "Drafting a reply about how I work..."
 _PROGRESS_UNSUPPORTED = "Working on a helpful explanation since I can't do that directly."
 _PROGRESS_UNSAFE = "That request looked unsafe, so I'm sending a fallback instead."
@@ -81,7 +80,7 @@ class ChatService:
                 to=[request.message.sender_email],
                 msg_type=request.message.type,
                 subject=request.message.subject,
-                content="Got it - I'll keep you posted as I work on this.",
+                content="thinking...",
                 channel_name=request.message.display_recipient,
             )
         except Exception:
@@ -111,7 +110,6 @@ class ChatService:
             self._logger.info("%s sent message '%s'", message.sender_email, message.content)
 
             self._record_user_message(message, history)
-            self._send_progress_update(message, _PROGRESS_INITIAL)
 
             if self._enable_langgraph:
                 response_text = self._run_langgraph_flow(request, history)

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -194,7 +194,7 @@ def test_process_user_message_database_flow(monkeypatch, sql_service):
     assert contents == [  # noqa: S101
         "Figuring out the best way to help.",
         "Checking the database for the details you asked about.",
-        "I have the data - summarizing it for you now.",
+        "I have the data - summarizing it for you now...",
         "There is one result.",
     ]
     assert mysql.last_query == "SELECT 1"  # noqa: S101
@@ -334,7 +334,7 @@ def test_process_user_message_database_salvage(monkeypatch, sql_service):
     assert contents == [  # noqa: S101
         "Figuring out the best way to help.",
         "Checking the database for the details you asked about.",
-        "I have the data - summarizing it for you now.",
+        "I have the data - summarizing it for you now...",
         "Use fallback",
     ]
     saved = history.get("user@example.com")

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -170,8 +170,8 @@ def test_process_user_message_chatbot(monkeypatch, sql_service):
 
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
-        "Drafting a reply about how I work...",
+        "Figuring out the best way to help.",
+        "Drafting a reply about how I work.",
         "Hello there",
     ]
     saved = history.get("user@example.com")
@@ -192,9 +192,9 @@ def test_process_user_message_database_flow(monkeypatch, sql_service):
 
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
-        "Checking the database for the details you asked about...",
-        "I have the data - summarizing it for you now...",
+        "Figuring out the best way to help.",
+        "Checking the database for the details you asked about.",
+        "I have the data - summarizing it for you now.",
         "There is one result.",
     ]
     assert mysql.last_query == "SELECT 1"  # noqa: S101
@@ -277,7 +277,7 @@ def test_process_user_message_other(monkeypatch, sql_service):
 
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
+        "Figuring out the best way to help.",
         "Working on a helpful explanation since I can't do that directly.",
         "Cannot help",
     ]
@@ -332,9 +332,9 @@ def test_process_user_message_database_salvage(monkeypatch, sql_service):
     assert mysql.last_query == "SELECT name"  # noqa: S101
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
-        "Checking the database for the details you asked about...",
-        "I have the data - summarizing it for you now...",
+        "Figuring out the best way to help.",
+        "Checking the database for the details you asked about.",
+        "I have the data - summarizing it for you now.",
         "Use fallback",
     ]
     saved = history.get("user@example.com")
@@ -359,8 +359,8 @@ def test_process_user_message_unsafe_sql(monkeypatch, sql_service):
     friendly = DEFAULT_FALLBACK_MESSAGE
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
-        "Checking the database for the details you asked about...",
+        "Figuring out the best way to help.",
+        "Checking the database for the details you asked about.",
         "That request looked unsafe, so I'm sending a fallback instead.",
         friendly,
     ]
@@ -433,8 +433,8 @@ def test_process_user_message_with_langgraph(monkeypatch, sql_service):
 
     contents = [entry["content"] for entry in zulip.sent]
     assert contents == [  # noqa: S101
-        "Figuring out the best way to help...",
-        "Drafting a reply about how I work...",
+        "Figuring out the best way to help.",
+        "Drafting a reply about how I work.",
         "LangGraph reply",
     ]
     assert history.get("user@example.com")[-1]["parts"] == ["LangGraph reply"]  # noqa: S101


### PR DESCRIPTION
## Summary
- send progress updates to Zulip users as each chat stage runs
- reuse helper to emit status across legacy and LangGraph flows
- expand tests to cover messaging sequences

## Testing
- ruff check fred_zulip_bot tests
- ruff format --check fred_zulip_bot tests
- mypy fred_zulip_bot
- pytest
